### PR TITLE
添加ClawdTalk技能 - AI代理语音通话和短信

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ curl -fsSL https://openclaw.ai/install.sh | bash
 
 - 🏪 ClawHub 官方市场：93个精选 Skills
 - ⭐ 必装 Skills Top 10：文件管理、网页搜索、日历同步
+- 📞 **ClawdTalk**：AI代理语音通话和短信技能，支持电话拨打、短信收发、通话转录
 - 🌟 **Skills双幻神**：find-skills（智能发现）+ ProactiveAgent（主动预测）
 - 🛠️ 自定义 Skills 开发：打造专属技能
 - 📦 Skills 管理技巧：安装、更新、卸载

--- a/appendix/B-skills-catalog.md
+++ b/appendix/B-skills-catalog.md
@@ -343,7 +343,43 @@ clawhub install debug-helper
 
 ## B.2 社区热门Skills
 
+---
+
 ### B.2.1 通讯工具类
+
+#### 📞 ClawdTalk（语音通话与短信）
+
+**功能**：
+- 拨打和接听电话
+- 发送和接收短信
+- AI驱动的通话任务
+- 通话转录和摘要
+
+**安装**：
+```bash
+clawhub install clawdtalk-client
+```
+
+**使用示例**：
+```
+"帮我给张三打个电话"
+"帮我发一条短信给李四：会议取消了"
+"帮我设置一个自动回访任务"
+```
+
+**推荐指数**：⭐⭐⭐⭐⭐
+
+**适用场景**：
+- 需要AI代理拨打电话
+- 需要发送短信通知
+- 需要自动化客户回访
+
+**链接**：
+- GitHub：https://github.com/team-telnyx/clawdtalk-client
+- 官网：https://clawdtalk.com
+- 基于：Telnyx Voice AI & Messaging APIs
+
+---
 
 #### 💬 feishu（飞书集成）
 


### PR DESCRIPTION
添加 [ClawdTalk](https://clawdtalk.com) - OpenClaw 的语音通话和短信技能，由 [Telnyx](https://telnyx.com) 提供支持。

**功能特点：**
- 让AI代理拨打和接听电话
- 发送和接收短信消息
- AI驱动的通话任务，支持自定义目标
- 通话转录和摘要

**链接：**
- GitHub: https://github.com/team-telnyx/clawdtalk-client
- 官网: https://clawdtalk.com
- 基于: Telnyx Voice AI & Messaging APIs

**更改内容：**
- 在附录B添加ClawdTalk技能说明
- 在README.md添加技能推荐