### PR TITLE
Add cc-soul — cognitive architecture plugin (memory, personality, emotion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ openclaw gateway restart
 - **ClawHub技能广场**：https://clawhub.ai
 - **Awesome Skills合集**：https://github.com/VoltAgent/awesome-openclaw-skills
 
+## 🔌 推荐插件
+
+| 插件名称 | 链接 | 核心功能 |
+|----------|------|----------|
+| **cc-soul** | [GitHub](https://github.com/wenroudeyu-collab/cc-soul) · [npm](https://www.npmjs.com/package/@cc-soul/openclaw) · [ClawHub](https://clawhub.ai/wenroudeyu-collab/cc-soul) | 认知架构插件 — 10,000+ 条持久记忆 + 语义搜索、10 个人格自动切换、情绪检测 + 7 天情绪弧线、梦境模式跨领域联想、纠正归因自我进化。50 个模块，20K+ 行 TypeScript，123 项功能。安装：`openclaw plugins install @cc-soul/openclaw` |
+
 ## 💡 实战案例精选
 
 ### 📦 配置示例（开箱即用）


### PR DESCRIPTION
## cc-soul 认知架构插件

在「官方资源」后新增「推荐插件」板块，收录 cc-soul。

### 核心亮点

- **10,000+ 条持久记忆** + 语义搜索 — AI 永不遗忘
- **10 个人格自动切换**（工程师/朋友/导师/军师等）— 场景感知对话
- **情绪检测 + 7 天情绪弧线** — 感知用户情绪
- **梦境模式** — 空闲时跨领域联想
- **纠正归因** — 分析出错原因，不重复犯错
- **举一反三** — 每条回复自动扩展思考

**50 个模块 | 20K+ 行 TypeScript | 123 项功能**

### 链接

- ClawHub: https://clawhub.ai/wenroudeyu-collab/cc-soul
- GitHub: https://github.com/wenroudeyu-collab/cc-soul
- npm: https://www.npmjs.com/package/@cc-soul/openclaw

### 安装

```bash
openclaw plugins install @cc-soul/openclaw
```