### PR TITLE
添加产品经理 Agent Skills 到官方资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ openclaw gateway restart
 - **GitHub仓库**：https://github.com/openclaw/openclaw
 - **ClawHub技能广场**：https://clawhub.ai
 - **Awesome Skills合集**：https://github.com/VoltAgent/awesome-openclaw-skills
+- **产品经理 Agent Skills**：https://github.com/Digidai/product-manager-skills — 资深产品经理 Agent，6 个知识域、30+ 框架、32 个 SaaS 指标公式、12 个模板、反模式检测
 
 ## 💡 实战案例精选
 


### PR DESCRIPTION
在官方资源部分添加 [product-manager-skills](https://github.com/Digidai/product-manager-skills) 链接。

资深产品经理 Agent，6 个知识域、30+ 框架、32 个 SaaS 指标公式、12 个模板、反模式检测。纯 Markdown，零脚本。